### PR TITLE
Update Unity workflow

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -18,22 +18,20 @@ jobs:
           path: ~/.cache/unity3d
           key: ${{ runner.os }}-unity
 
-      - name: Setup Unity
-        uses: game-ci/unity-actions/setup@v3
+      - name: Rodar testes (EditMode)
+        uses: game-ci/unity-test-runner@v4
         with:
           unityVersion: 2022.3.0f1
-
-      - name: Rodar testes (EditMode)
-        uses: game-ci/unity-actions/test@v3
-        with:
           testMode: editmode
 
       - name: Rodar testes (PlayMode)
-        uses: game-ci/unity-actions/test@v3
+        uses: game-ci/unity-test-runner@v4
         with:
+          unityVersion: 2022.3.0f1
           testMode: playmode
 
       - name: Executar prefab builder
-        uses: game-ci/unity-actions/cli@v3
+        uses: game-ci/cli@main
         with:
+          unityVersion: 2022.3.0f1
           args: -batchmode -projectPath . -executeMethod BuildadorPrefabs.CriarPrefabs -quit


### PR DESCRIPTION
## Summary
- migrate to `game-ci/unity-test-runner@v4`
- use `game-ci/cli@main` for prefab builder
- remove obsolete setup action