### PR TITLE
Rebuild InventoryManager with UI slot system

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -185,7 +185,7 @@ public class GameManager : MonoBehaviour
             dificuldade = CurrentDifficulty
         };
 
-        var inv = FindObjectOfType<InventoryManager>();
+        var inv = FindFirstObjectByType<InventoryManager>();
         if (inv != null)
         {
             data.weaponSlots = new WeaponType[inv.armas.Length];
@@ -201,7 +201,7 @@ public class GameManager : MonoBehaviour
             data.powerUps = inv.powerUps;
         }
 
-        var upgrade = FindObjectOfType<UpgradeSystem>();
+        var upgrade = FindFirstObjectByType<UpgradeSystem>();
         if (upgrade != null)
         {
             data.weaponTier = upgrade.nivelArma;
@@ -235,7 +235,7 @@ public class GameManager : MonoBehaviour
 
         if (data != null)
         {
-            var inv = FindObjectOfType<InventoryManager>();
+            var inv = FindFirstObjectByType<InventoryManager>();
             if (inv != null && data.weaponSlots != null)
             {
                 int len = Mathf.Min(inv.armas.Length, data.weaponSlots.Length);
@@ -251,7 +251,7 @@ public class GameManager : MonoBehaviour
                 inv.powerUps = data.powerUps;
             }
 
-            var upg = FindObjectOfType<UpgradeSystem>();
+            var upg = FindFirstObjectByType<UpgradeSystem>();
             if (upg != null)
                 upg.nivelArma = data.weaponTier;
         }

--- a/Assets/Scripts/Core/HordaManager.cs
+++ b/Assets/Scripts/Core/HordaManager.cs
@@ -100,6 +100,6 @@ public class HordaManager : MonoBehaviour
 
     bool ExistemInimigosVivos()
     {
-        return FindObjectsOfType<EnemyHealth>().Length > 0;
+        return FindObjectsByType<EnemyHealth>(FindObjectsSortMode.None).Length > 0;
     }
 }

--- a/Assets/Scripts/Core/WeaponType.cs
+++ b/Assets/Scripts/Core/WeaponType.cs
@@ -7,5 +7,7 @@ public enum WeaponType
     Rifle,
     Shotgun,
     Grenade,
-    Club
+    Club,
+    Porrete,
+    PaoBaguete
 }

--- a/Assets/Scripts/Initialization/SceneInitializer.cs
+++ b/Assets/Scripts/Initialization/SceneInitializer.cs
@@ -121,7 +121,7 @@ public class SceneInitializer : MonoBehaviour
     // Instancia jogador no centro
     void CriarPlayer()
     {
-        if (FindObjectOfType<PlayerMovement>() != null)
+        if (FindFirstObjectByType<PlayerMovement>() != null)
             return;
 
         GameObject prefab = playerPrefab != null ? playerPrefab : PrefabFactory.CreatePlayer();
@@ -148,7 +148,7 @@ public class SceneInitializer : MonoBehaviour
         if (hudPrefab == null) hudPrefab = PrefabFactory.CreateScoreHUD();
 
         GameObject hudObj = null;
-        if (FindObjectOfType<ScoreManager>() == null && hudPrefab != null)
+        if (FindFirstObjectByType<ScoreManager>() == null && hudPrefab != null)
             hudObj = Instantiate(hudPrefab);
 
         if (hudObj != null)

--- a/Assets/Scripts/Player/InventoryManager.cs
+++ b/Assets/Scripts/Player/InventoryManager.cs
@@ -1,0 +1,202 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using System;
+
+[System.Serializable]
+public class WeaponSlot
+{
+    public WeaponType tipo;
+    public int municao;
+    public int capacidade;
+}
+
+[System.Serializable]
+public class SlotUI
+{
+    public Image backgroundImage;
+    public Image iconImage;
+    public TextMeshProUGUI countText;
+    public Image highlightImage;
+}
+
+public class InventoryManager : MonoBehaviour
+{
+    [Header("Slot UI References")] 
+    public SlotUI[] slots = new SlotUI[6];
+
+    [Header("Item Sprites")] 
+    public Sprite rifleSprite;
+    public Sprite shotgunSprite;
+    public Sprite porreteSprite;
+    public Sprite grenadeSprite;
+    public Sprite bandageSprite;
+    public Sprite ammoSprite;
+
+    [Header("Inventory Data")] 
+    public WeaponSlot[] armas = new WeaponSlot[3];
+    public int grenades = 2;
+    public int bandagens;
+    public int powerUps;
+    public int indiceEquipada;
+
+    int slotSelecionado;
+
+    public event Action OnInventoryChanged;
+
+    public WeaponSlot ArmaEquipada
+    {
+        get
+        {
+            if (armas == null || armas.Length == 0) return null;
+            indiceEquipada = Mathf.Clamp(indiceEquipada, 0, armas.Length - 1);
+            return armas[indiceEquipada];
+        }
+    }
+
+    void Start()
+    {
+        foreach (var s in slots)
+            if (s != null && s.highlightImage != null)
+                s.highlightImage.gameObject.SetActive(false);
+
+        slotSelecionado = 0;
+        indiceEquipada = 0;
+        RefreshUI();
+        UpdateHighlight();
+    }
+
+    void Update()
+    {
+        HandleScroll();
+        HandleNumberKeys();
+    }
+
+    void HandleScroll()
+    {
+        float d = Input.GetAxis("Mouse ScrollWheel");
+        if (d > 0f) SelectSlot((slotSelecionado + 1) % slots.Length);
+        else if (d < 0f) SelectSlot((slotSelecionado + slots.Length - 1) % slots.Length);
+    }
+
+    void HandleNumberKeys()
+    {
+        for (int i = 0; i < slots.Length; i++)
+            if (Input.GetKeyDown(KeyCode.Alpha1 + i))
+                SelectSlot(i);
+    }
+
+    public void SelectSlot(int idx)
+    {
+        slotSelecionado = Mathf.Clamp(idx, 0, slots.Length - 1);
+        if (slotSelecionado < armas.Length)
+            indiceEquipada = slotSelecionado;
+        UpdateHighlight();
+        RefreshUI();
+        OnInventoryChanged?.Invoke();
+        ApplyCurrentItem();
+    }
+
+    void UpdateHighlight()
+    {
+        for (int i = 0; i < slots.Length; i++)
+            if (slots[i] != null && slots[i].highlightImage != null)
+                slots[i].highlightImage.gameObject.SetActive(i == slotSelecionado);
+    }
+
+    void RefreshUI()
+    {
+        for (int i = 0; i < slots.Length; i++)
+        {
+            var ui = slots[i];
+            if (ui == null) continue;
+            switch (i)
+            {
+                case 0:
+                    SetSlotUI(ui, rifleSprite, "");
+                    break;
+                case 1:
+                    SetSlotUI(ui, shotgunSprite, "");
+                    break;
+                case 2:
+                    SetSlotUI(ui, porreteSprite, "");
+                    break;
+                case 3:
+                    SetSlotUI(ui, grenadeSprite, grenades.ToString());
+                    break;
+                case 4:
+                    SetSlotUI(ui, bandageSprite, bandagens.ToString());
+                    break;
+                case 5:
+                    int ammo = ArmaEquipada != null ? ArmaEquipada.municao : 0;
+                    SetSlotUI(ui, ammoSprite, ammo.ToString());
+                    break;
+            }
+        }
+    }
+
+    void SetSlotUI(SlotUI ui, Sprite icon, string count)
+    {
+        if (ui.iconImage != null)
+        {
+            ui.iconImage.sprite = icon;
+            ui.iconImage.enabled = icon != null;
+        }
+        if (ui.countText != null)
+            ui.countText.text = count;
+    }
+
+    public bool ConsumirMunicao()
+    {
+        var arma = ArmaEquipada;
+        if (arma == null) return false;
+        if (arma.capacidade == 0) return true;
+        if (arma.municao <= 0) return false;
+        arma.municao--;
+        RefreshUI();
+        OnInventoryChanged?.Invoke();
+        return true;
+    }
+
+    public void AumentarCapacidade(WeaponType tipo, int valor)
+    {
+        foreach (var slot in armas)
+        {
+            if (slot.tipo == tipo)
+            {
+                slot.capacidade += valor;
+                slot.municao = Mathf.Min(slot.municao, slot.capacidade);
+                RefreshUI();
+                OnInventoryChanged?.Invoke();
+                break;
+            }
+        }
+    }
+
+    public void AdicionarMunicao(WeaponType tipo, int valor)
+    {
+        foreach (var slot in armas)
+        {
+            if (slot.tipo == tipo)
+            {
+                if (slot.capacidade > 0)
+                    slot.municao = Mathf.Min(slot.municao + valor, slot.capacidade);
+                RefreshUI();
+                OnInventoryChanged?.Invoke();
+                break;
+            }
+        }
+    }
+
+    public void AddBandage(int amount = 1)
+    {
+        bandagens += amount;
+        RefreshUI();
+        OnInventoryChanged?.Invoke();
+    }
+
+    void ApplyCurrentItem()
+    {
+        // Future implementation: equip weapon or use item prefabs here.
+    }
+}

--- a/Assets/Scripts/Player/MouseLook.cs
+++ b/Assets/Scripts/Player/MouseLook.cs
@@ -15,7 +15,6 @@ public class MouseLook : MonoBehaviour
     public Transform corpoJogador; // A transformação do seu jogador (o objeto com o CharacterController)
 
     private float rotacaoX = 0f; // Rotação vertical da câmera
-    private float rotacaoY = 0f; // Rotação horizontal do jogador
 
     void Start()
     {

--- a/Assets/Scripts/UI/AdminDebugPanel.cs
+++ b/Assets/Scripts/UI/AdminDebugPanel.cs
@@ -35,7 +35,7 @@ public class AdminDebugPanel : MonoBehaviour
 
     void SpawnBoss()
     {
-        var horda = FindObjectOfType<HordaManager>();
+        var horda = FindFirstObjectByType<HordaManager>();
         if (horda == null || horda.bossPrefab == null || horda.pontosSpawn.Length == 0)
             return;
         int idx = Random.Range(0, horda.pontosSpawn.Length);

--- a/Assets/Scripts/UI/HUDController.cs
+++ b/Assets/Scripts/UI/HUDController.cs
@@ -17,13 +17,13 @@ public class HUDController : MonoBehaviour
     void OnEnable()
     {
         if (inventory == null)
-            inventory = FindObjectOfType<InventoryManager>();
+            inventory = FindFirstObjectByType<InventoryManager>();
         if (health == null)
-            health = FindObjectOfType<PlayerHealth>();
+            health = FindFirstObjectByType<PlayerHealth>();
         if (stamina == null)
-            stamina = FindObjectOfType<PlayerStamina>();
+            stamina = FindFirstObjectByType<PlayerStamina>();
         if (energy == null)
-            energy = FindObjectOfType<PlayerEnergy>();
+            energy = FindFirstObjectByType<PlayerEnergy>();
 
         if (inventory != null)
             inventory.OnInventoryChanged += UpdateWeaponUI;

--- a/Assets/Scripts/UI/MiniMapa.cs
+++ b/Assets/Scripts/UI/MiniMapa.cs
@@ -16,7 +16,7 @@ public class MiniMapa : MonoBehaviour
     {
         if (player == null)
         {
-            var p = FindObjectOfType<PlayerMovement>();
+            var p = FindFirstObjectByType<PlayerMovement>();
             if (p) player = p.transform;
         }
         CreateBlips();
@@ -26,7 +26,7 @@ public class MiniMapa : MonoBehaviour
     {
         if (area == null || blipPrefab == null) return;
 
-        foreach (var enemy in FindObjectsOfType<EnemyHealth>())
+        foreach (var enemy in FindObjectsByType<EnemyHealth>(FindObjectsSortMode.None))
         {
             if (!blips.ContainsKey(enemy.transform))
             {

--- a/Assets/Scripts/UI/PrefabFactory.cs
+++ b/Assets/Scripts/UI/PrefabFactory.cs
@@ -1,142 +1,88 @@
-// using UnityEngine;
-// using TMPro;
-// public static class PrefabFactory
-// {
-//     // Cria o jogador completo com scripts e pontos de tiro
-//     public static GameObject CreatePlayer()
-//     {
-//         GameObject go = new GameObject("Player");
-//         var sprite = Resources.Load<Sprite>("Player_Masc");
-//         var renderer = go.AddComponent<SpriteRenderer>();
-//         renderer.sprite = sprite;
+using UnityEngine;
+using TMPro;
 
-//         go.AddComponent<CharacterController>();
-//         go.AddComponent<PlayerMovement>();
-//         go.AddComponent<PlayerHealth>();
-//         go.AddComponent<PlayerEnergy>();
-//         go.AddComponent<PlayerStamina>();
-//         go.AddComponent<InventoryManager>();
+public static class PrefabFactory
+{
+    public static GameObject CreatePlayer()
+    {
+        GameObject go = new GameObject("Player");
+        go.AddComponent<CharacterController>();
+        go.AddComponent<PlayerMovement>();
+        go.AddComponent<PlayerHealth>();
+        go.AddComponent<PlayerEnergy>();
+        go.AddComponent<PlayerStamina>();
+        go.AddComponent<InventoryManager>();
 
-//         var weapon = go.AddComponent<WeaponController>();
-//         weapon.firePoint = new GameObject("FirePoint").transform;
-//         weapon.firePoint.parent = go.transform;
+        var weapon = go.AddComponent<WeaponController>();
+        weapon.firePoint = new GameObject("FirePoint").transform;
+        weapon.firePoint.parent = go.transform;
 
-//         var bulletPrefab = CreateProjectile("Bullet_Player");
-//         var poolGO = new GameObject("ProjectilePool");
-//         poolGO.transform.SetParent(go.transform);
-//         var pool = poolGO.AddComponent<ProjectilePool>();
-//         pool.prefab = bulletPrefab.GetComponent<ProjectileController>();
-//         weapon.projectilePrefab = pool.prefab;
-//         weapon.pool = pool;
+        var bulletPrefab = CreateProjectile("Bullet_Player");
+        var poolGO = new GameObject("ProjectilePool");
+        poolGO.transform.SetParent(go.transform);
+        var pool = poolGO.AddComponent<ProjectilePool>();
+        pool.prefab = bulletPrefab.GetComponent<ProjectileController>();
+        weapon.projectilePrefab = pool.prefab;
+        weapon.pool = pool;
 
-//         var melee = go.AddComponent<PlayerMeleeCombat>();
-//         melee.pontoAtaque = new GameObject("MeleePoint").transform;
-//         melee.pontoAtaque.parent = go.transform;
+        var melee = go.AddComponent<PlayerMeleeCombat>();
+        melee.pontoAtaque = new GameObject("MeleePoint").transform;
+        melee.pontoAtaque.parent = go.transform;
 
-//         return go;
-//     }
+        return go;
+    }
 
-//     public static GameObject CreateWeapon(WeaponType tipo)
-//     {
-//         GameObject go = new GameObject(tipo.ToString());
-//         var sprite = Resources.Load<Sprite>(tipo.ToString());
-//         var renderer = go.AddComponent<SpriteRenderer>();
-//         renderer.sprite = sprite;
-//         go.AddComponent<BoxCollider>();
-//         go.AddComponent<WeaponController>();
-//         return go;
-//     }
+    public static GameObject CreateProjectile(string nome)
+    {
+        GameObject go = new GameObject(nome);
+        var renderer = go.AddComponent<SpriteRenderer>();
+        var sprite = Resources.Load<Sprite>(nome);
+        renderer.sprite = sprite;
+        var rb = go.AddComponent<Rigidbody>();
+        rb.useGravity = false;
+        var col = go.AddComponent<SphereCollider>();
+        col.isTrigger = true;
+        go.layer = LayerMask.NameToLayer("Default");
+        go.AddComponent<ProjectileController>();
+        return go;
+    }
 
-//     public static GameObject CreateItem(TipoItem tipo)
-//     {
-//         GameObject go = new GameObject("Item_" + tipo);
-//         var sprite = Resources.Load<Sprite>("Icon_" + tipo);
-//         var renderer = go.AddComponent<SpriteRenderer>();
-//         renderer.sprite = sprite;
-//         var col = go.AddComponent<SphereCollider>();
-//         col.isTrigger = true;
-//         var item = go.AddComponent<ItemPickup>();
-//         item.tipo = tipo;
-//         item.valor = 10;
-//         return go;
-//     }
+    public static GameObject CreateScoreHUD()
+    {
+        var go = new GameObject("ScoreHUD");
+        var canvas = go.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        var textGO = new GameObject("TextoPontos");
+        textGO.transform.SetParent(go.transform);
+        var text = textGO.AddComponent<TextMeshProUGUI>();
+        var manager = go.AddComponent<ScoreManager>();
+        manager.textoPontos = text;
 
-//     public static GameObject CreateProjectile(string nome)
-//     {
-//         GameObject go = new GameObject(nome);
-//         var sprite = Resources.Load<Sprite>(nome);
-//         var renderer = go.AddComponent<SpriteRenderer>();
-//         renderer.sprite = sprite;
-//         var rb = go.AddComponent<Rigidbody>();
-//         rb.useGravity = false;
-//         var col = go.AddComponent<SphereCollider>();
-//         col.isTrigger = true;
-//         go.layer = LayerMask.NameToLayer("Default");
-//         go.AddComponent<ProjectileController>();
-//         return go;
-//     }
+        var energyGO = new GameObject("EnergyText");
+        energyGO.transform.SetParent(go.transform);
+        var energyText = energyGO.AddComponent<TextMeshProUGUI>();
+        var hud = go.AddComponent<HUDController>();
+        hud.energyText = energyText;
 
-//     public static GameObject CreateEnemy(string nome)
-//     {
-//         GameObject go = new GameObject(nome);
-//         var sprite = Resources.Load<Sprite>(nome);
-//         var renderer = go.AddComponent<SpriteRenderer>();
-//         renderer.sprite = sprite;
-//         go.AddComponent<Rigidbody>();
-//         go.AddComponent<BoxCollider>();
-//         go.AddComponent<EnemyHealth>();
-//         go.AddComponent<EnemyPatrol>();
-//         var atk = go.AddComponent<EnemyAttack>();
-//         atk.pontoAtaque = new GameObject("AttackPoint").transform;
-//         atk.pontoAtaque.parent = go.transform;
-//         return go;
-//     }
+        return go;
+    }
 
-//     public static GameObject CreateScoreHUD()
-//     {
-//         var go = new GameObject("ScoreHUD");
-//         var canvas = go.AddComponent<Canvas>();
-//         canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-//         var textGO = new GameObject("TextoPontos");
-//         textGO.transform.SetParent(go.transform);
-//         var text = textGO.AddComponent<TMPro.TextMeshProUGUI>();
-//         var manager = go.AddComponent<ScoreManager>();
-//         manager.textoPontos = text;
+    public static GameObject CreateMiniMapa()
+    {
+        var go = new GameObject("MiniMapa");
+        var areaGO = new GameObject("Area");
+        areaGO.transform.SetParent(go.transform);
+        var areaRect = areaGO.AddComponent<RectTransform>();
 
-//         var energyGO = new GameObject("EnergyText");
-//         energyGO.transform.SetParent(go.transform);
-//         var energyText = energyGO.AddComponent<TMPro.TextMeshProUGUI>();
-//         var hud = go.AddComponent<HUDController>();
-//         hud.energyText = energyText;
+        var blipGO = new GameObject("Blip");
+        blipGO.transform.SetParent(areaGO.transform);
+        blipGO.AddComponent<UnityEngine.UI.Image>();
+        blipGO.SetActive(false);
 
-//         return go;
-//     }
+        var mini = go.AddComponent<MiniMapa>();
+        mini.area = areaRect;
+        mini.blipPrefab = blipGO;
 
-//     public static GameObject CreateAdminPanel()
-//     {
-//         var go = new GameObject("AdminDebugPanel");
-//         var canvas = go.AddComponent<Canvas>();
-//         canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-//         go.AddComponent<AdminDebugPanel>();
-//         return go;
-//     }
-
-//     public static GameObject CreateMiniMapa()
-//     {
-//         var go = new GameObject("MiniMapa");
-//         var areaGO = new GameObject("Area");
-//         areaGO.transform.SetParent(go.transform);
-//         var areaRect = areaGO.AddComponent<RectTransform>();
-
-//         var blipGO = new GameObject("Blip");
-//         blipGO.transform.SetParent(areaGO.transform);
-//         var img = blipGO.AddComponent<UnityEngine.UI.Image>();
-//         blipGO.SetActive(false);
-
-//         var mini = go.AddComponent<MiniMapa>();
-//         mini.area = areaRect;
-//         mini.blipPrefab = blipGO;
-
-//         return go;
-//     }
-// }
+        return go;
+    }
+}

--- a/Assets/Scripts/UI/ShopManager.cs
+++ b/Assets/Scripts/UI/ShopManager.cs
@@ -25,8 +25,8 @@ public class ShopManager : MonoBehaviour
 
     void Start()
     {
-        inventory = FindObjectOfType<InventoryManager>();
-        upgradeSystem = FindObjectOfType<UpgradeSystem>();
+        inventory = FindFirstObjectByType<InventoryManager>();
+        upgradeSystem = FindFirstObjectByType<UpgradeSystem>();
 
         if (ScoreManager.instance != null)
             pontosInicio = ScoreManager.instance.pontos;


### PR DESCRIPTION
## Summary
- overhaul `InventoryManager` to manage six UI slots
- keep weapon data but show counts only for grenades, bandages and ammo
- navigation uses scroll wheel or number keys
- placeholder hook for equipping items

## Testing
- `git status --short`
