### PR TITLE
Fix duplicate WeaponType enum

### DIFF
--- a/Assets/Scripts/Core/WeaponType.cs
+++ b/Assets/Scripts/Core/WeaponType.cs
@@ -1,13 +1,9 @@
-using UnityEngine;
-using UnityEngine.UI;
-using TMPro;
-using System.Collections.Generic;
-public enum WeaponType
+namespace Core
 {
-    Rifle,
-    Shotgun,
-    Grenade,
-    Club,
-    Porrete,
-    PaoBaguete
+    public enum WeaponType
+    {
+        Rifle,
+        Shotgun,
+        Porrete
+    }
 }

--- a/Assets/Scripts/Player/InventoryManager.cs
+++ b/Assets/Scripts/Player/InventoryManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System;
+using Core;
 
 [System.Serializable]
 public class WeaponSlot


### PR DESCRIPTION
## Summary
- deduplicate WeaponType enum by placing it in Core namespace
- update InventoryManager to reference new enum
