### PR TITLE
Fix inventory references and HUD controller

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -18,6 +18,7 @@ public class GameManager : MonoBehaviour
     int pendingScore = -1;
     SaveData pendingData = null;
     const int startSceneIndex = 1; // Fase1_Deserto
+    InventoryManager inventory;
 
     void Awake()
     {
@@ -25,6 +26,7 @@ public class GameManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
+            inventory = FindFirstObjectByType<InventoryManager>();
         }
         else
         {
@@ -185,20 +187,19 @@ public class GameManager : MonoBehaviour
             dificuldade = CurrentDifficulty
         };
 
-        var inv = FindFirstObjectByType<InventoryManager>();
-        if (inv != null)
+        if (inventory != null)
         {
-            data.weaponSlots = new WeaponType[inv.armas.Length];
-            data.weaponAmmo = new int[inv.armas.Length];
-            data.ammoCapacidade = new int[inv.armas.Length];
-            for (int i = 0; i < inv.armas.Length; i++)
+            data.weaponSlots = new WeaponType[inventory.armas.Length];
+            data.weaponAmmo = new int[inventory.armas.Length];
+            data.ammoCapacidade = new int[inventory.armas.Length];
+            for (int i = 0; i < inventory.armas.Length; i++)
             {
-                data.weaponSlots[i] = inv.armas[i].tipo;
-                data.weaponAmmo[i] = inv.armas[i].municao;
-                data.ammoCapacidade[i] = inv.armas[i].capacidade;
+                data.weaponSlots[i] = inventory.armas[i].tipo;
+                data.weaponAmmo[i] = inventory.armas[i].municao;
+                data.ammoCapacidade[i] = inventory.armas[i].capacidade;
             }
-            data.bandagens = inv.bandagens;
-            data.powerUps = inv.powerUps;
+            data.bandagens = inventory.bandagens;
+            data.powerUps = inventory.powerUps;
         }
 
         var upgrade = FindFirstObjectByType<UpgradeSystem>();
@@ -226,6 +227,8 @@ public class GameManager : MonoBehaviour
         // Carrega dados do slot atual se não houver pendência do StartGame
         var data = pendingData != null ? pendingData : SaveSystem.Load(CurrentSlot);
 
+        inventory = FindFirstObjectByType<InventoryManager>();
+
         if (ScoreManager.instance != null)
         {
             int score = pendingScore >= 0 ? pendingScore : (data != null ? data.pontos : 0);
@@ -235,21 +238,21 @@ public class GameManager : MonoBehaviour
 
         if (data != null)
         {
-            var inv = FindFirstObjectByType<InventoryManager>();
-            if (inv != null && data.weaponSlots != null)
+            if (inventory != null && data.weaponSlots != null)
             {
-                int len = Mathf.Min(inv.armas.Length, data.weaponSlots.Length);
+                int len = Mathf.Min(inventory.armas.Length, data.weaponSlots.Length);
                 for (int i = 0; i < len; i++)
                 {
-                    inv.armas[i].tipo = data.weaponSlots[i];
+                    inventory.armas[i].tipo = data.weaponSlots[i];
                     if (data.weaponAmmo != null && data.weaponAmmo.Length > i)
-                        inv.armas[i].municao = data.weaponAmmo[i];
+                        inventory.armas[i].municao = data.weaponAmmo[i];
                     if (data.ammoCapacidade != null && data.ammoCapacidade.Length > i)
-                        inv.armas[i].capacidade = data.ammoCapacidade[i];
+                        inventory.armas[i].capacidade = data.ammoCapacidade[i];
                 }
-                inv.bandagens = data.bandagens;
-                inv.powerUps = data.powerUps;
+                inventory.bandagens = data.bandagens;
+                inventory.powerUps = data.powerUps;
             }
+
 
             var upg = FindFirstObjectByType<UpgradeSystem>();
             if (upg != null)

--- a/Assets/Scripts/Core/Weapon.cs
+++ b/Assets/Scripts/Core/Weapon.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+[System.Serializable]
+public class Weapon
+{
+    public WeaponType tipo;
+    public int municao;
+    public int capacidade;
+}

--- a/Assets/Scripts/UI/HUDController.cs
+++ b/Assets/Scripts/UI/HUDController.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using TMPro;
+
+public class HUDController : MonoBehaviour
+{
+    public TextMeshProUGUI energyText;
+    public TextMeshProUGUI healthText;
+    public TextMeshProUGUI staminaText;
+
+    PlayerEnergy energy;
+    PlayerHealth health;
+    PlayerStamina stamina;
+
+    void Awake()
+    {
+        energy = FindFirstObjectByType<PlayerEnergy>();
+        health = FindFirstObjectByType<PlayerHealth>();
+        stamina = FindFirstObjectByType<PlayerStamina>();
+
+        if (energy != null) energy.OnEnergyChanged += UpdateEnergy;
+        if (health != null) health.OnHealthChanged += UpdateHealth;
+        if (stamina != null) stamina.OnStaminaChanged += UpdateStamina;
+
+        if (energy != null) UpdateEnergy(energy.currentEnergy);
+        if (health != null) UpdateHealth(health.currentHealth);
+        if (stamina != null) UpdateStamina(stamina.currentStamina);
+    }
+
+    void OnDestroy()
+    {
+        if (energy != null) energy.OnEnergyChanged -= UpdateEnergy;
+        if (health != null) health.OnHealthChanged -= UpdateHealth;
+        if (stamina != null) stamina.OnStaminaChanged -= UpdateStamina;
+    }
+
+    void UpdateEnergy(int value)
+    {
+        if (energyText != null)
+            energyText.text = "Energy: " + value;
+    }
+
+    void UpdateHealth(int value)
+    {
+        if (healthText != null)
+            healthText.text = "HP: " + value;
+    }
+
+    void UpdateStamina(int value)
+    {
+        if (staminaText != null)
+            staminaText.text = "Stamina: " + value;
+    }
+}

--- a/Assets/Scripts/UI/InventoryManager.cs
+++ b/Assets/Scripts/UI/InventoryManager.cs
@@ -23,6 +23,11 @@ public class InventoryManager : MonoBehaviour
     public Sprite bandageSprite;
     public Sprite ammoSprite;
 
+    // Coleções acessadas pelo GameManager
+    public Weapon[] armas = new Weapon[0];
+    public int bandagens = 0;
+    public int powerUps = 0;
+
     private int[] counts = new int[6];
     private int selectedIndex = 0;
 


### PR DESCRIPTION
## Summary
- add `Weapon` class to store weapon type, ammo and capacity
- expose weapon, bandage and powerUp fields on `InventoryManager`
- add `HUDController` script for UI elements
- keep a cached `InventoryManager` in `GameManager`

## Testing
- `dotnet` unavailable; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6875ede3fd4083239cc86387521244db